### PR TITLE
fixs bug in contact.fields

### DIFF
--- a/lib/verticalresponse/api/contact.rb
+++ b/lib/verticalresponse/api/contact.rb
@@ -18,7 +18,7 @@ module VerticalResponse
         end
 
         def fields(options = {})
-          Response.new get(resource_uri('fields'), build_query_params(options), options[:access_token])
+          Response.new(get(resource_uri('fields'), build_query_params(options)), options[:access_token])
         end
 
         def find_by_email(options = {})

--- a/lib/verticalresponse/api/oauth.rb
+++ b/lib/verticalresponse/api/oauth.rb
@@ -108,6 +108,12 @@ module VerticalResponse
         params.merge!({access_token: @access_token})
         VerticalResponse::API::CustomField.all(params)
       end
+
+      def fields(params = {}) #optional "type: 'all' or 'standard'~>(default)"
+        params.merge!({access_token: @access_token})
+        VerticalResponse::API::Contact.fields(params)
+      end
+
     end
   end
 end


### PR DESCRIPTION
Missing parenthesis was leading to "ArgumentError: wrong number of arguments" in get method at httparty.